### PR TITLE
Split send mail into 2 functions

### DIFF
--- a/src/zimbra/__init__.py
+++ b/src/zimbra/__init__.py
@@ -231,6 +231,16 @@ class ZimbraUser:
         return payload.encode("utf8"), boundary
 
     def send_raw_payload(self, payload: bytes, boundary: str) -> Response:
+        """
+        Sends a raw payload to the Web interface.
+
+            Parameters:
+                payload (bytes): The payload to send in the body of the request
+                boundary (str): The boundary that is used in the WebkitFormBoundary payload
+
+            Returns:
+                Response: A zimbra.Response object with response.True if payload was sent successfully
+        """
         if not self.authenticated:
             return Response(False, "Not Authenticated")
 


### PR DESCRIPTION
Fixes #21

The signature of `send_mail` has not changed but now 2 more functions are available:

```python
send_raw_payload(self, payload: bytes, boundary: str) -> Response

generate_webkit_payload(self, to: str, subject: str, body: str,
                                cc: Optional[str] = "", bcc: Optional[str] = "", replyto: Optional[str] = "", inreplyto: Optional[str] = "",
                                messageid: Optional[str] = "") -> Tuple[bytes, str]:
```

`generate_webkit_payload` returns `Tuple[bytes, str]` because it returns the generated payload and the boundary.